### PR TITLE
Do not require having From: to point to user e-mail from checkvist.

### DIFF
--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -142,6 +142,7 @@ sub _add_task {
         Content => [
             import_content  => encode_utf8($job->{text}),
             parse_tasks     => 1,
+            remote_key      => $job->{remotekey},
         ],
     );
 


### PR DESCRIPTION
With this change, import function will pick authentication directly from the remote_key.
