### PR TITLE
Add Markdown support, fix forwarding from GMail, add support for empty Subject line

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -85,9 +85,11 @@ sub parse_email {
 
     my ($body_text, $files)   = _parse_for_content($email);
     
-    $item_text = $subject // (split /\n/, $body_text // 'Created from E-Mail' )[0];
+    $item_text = $subject // (split /\n/, $body_text // 'Created from E-Mail')[0];
     $item_text =~ s/\s+$//;
-    $body_text =~ s/\s+$//;
+    if ($body_text) {
+	    $body_text =~ s/\s+$//;
+    }
     if ($item_text eq $body_text) {
 	    # Remove note if its text is the same as item text
 	    undef $body_text;

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -80,7 +80,8 @@ sub parse_email {
     $subject = $email->header('Subject');
     $from = (Email::Address->parse($email->header_obj->header_raw('From')))[0]->address;
 
-    my ($login, $remotekey, $list_id, $list_tag) = _parse_to($email->header_obj->header_raw('To'));
+    my $to_header = $email->header_obj->header_raw('Delivered-To') // $email->header_obj->header_raw('To');
+    my ($login, $remotekey, $list_id, $list_tag) = _parse_to($to_header);
 
     my ($body_text, $files)   = _parse_for_content($email);
 

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -72,7 +72,7 @@ sub _parse_to {
 sub parse_email {
     my $fh = pop;
 
-    my ($from, $to, $subject);
+    my ($from, $to, $subject, $item_text);
 
     binmode $fh, ':bytes';
     my $email = Email::MIME->new(join "", <$fh>);
@@ -84,6 +84,14 @@ sub parse_email {
     my ($login, $remotekey, $list_id, $list_tag) = _parse_to($to_header);
 
     my ($body_text, $files)   = _parse_for_content($email);
+    
+    $item_text = $subject // (split /\n/, $body_text // 'Created from E-Mail' )[0];
+    $item_text =~ s/\s+$//;
+    $body_text =~ s/\s+$//;
+    if ($item_text eq $body_text) {
+	    # Remove note if its text is the same as item text
+	    undef $body_text;
+	}
 
     $Last_Error = '';
     return {
@@ -94,7 +102,7 @@ sub parse_email {
 
         list_id     => $list_id,
         list_tag    => $list_tag,
-        text        => $subject,
+        text        => $item_text,
 
         ($body_text
             ? (note         => $body_text)

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -72,12 +72,11 @@ sub _parse_to {
 sub parse_email {
     my $fh = pop;
 
-    my ($from, $to, $subject, $item_text);
+    my ($from, $to, $item_text);
 
     binmode $fh, ':bytes';
     my $email = Email::MIME->new(join "", <$fh>);
 
-    $subject = $email->header('Subject');
     $from = (Email::Address->parse($email->header_obj->header_raw('From')))[0]->address;
 
     my $to_header = $email->header_obj->header_raw('Delivered-To') // $email->header_obj->header_raw('To');
@@ -85,7 +84,7 @@ sub parse_email {
 
     my ($body_text, $files)   = _parse_for_content($email);
     
-    $item_text = $subject // (split /\n/, $body_text // 'Created from E-Mail')[0];
+    $item_text = $email->header('Subject') // (split /\n/, $body_text // 'Created from E-Mail')[0];
     $item_text =~ s/\s+$//;
     if ($body_text) {
 	    $body_text =~ s/\s+$//;

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -84,15 +84,14 @@ sub parse_email {
 
     my ($body_text, $files)   = _parse_for_content($email);
     
-    $item_text = $email->header('Subject') // (split /\n/, $body_text // 'Created from E-Mail')[0];
+    my @lines = split(/\n/, $body_text || 'Created from E-Mail');
+    $item_text = $email->header('Subject') || $lines[0];
     $item_text =~ s/\s+$//;
-    if ($body_text) {
-	    $body_text =~ s/\s+$//;
-    }
     if ($item_text eq $body_text) {
 	    # Remove note if its text is the same as item text
 	    undef $body_text;
 	}
+	#say STDERR "Item text: $item_text";
 
     $Last_Error = '';
     return {

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -48,15 +48,20 @@ sub _parse_to {
         # we do not allow "." in remotekey to distinguish between
         # user$domain.com+remotekey@ and
         # remotekey+list_tag
+        # say STDERR "Item text: $_";
+
         # fortunately, Checkvist remotekeys do not contain "."
-        when (/^ ([^+.]+) \+ (\d+) $/xms) {
+        if (/^ ([^+.]+) \+ (\d+) $/xms) {
             ($remotekey, $list_id) = ($1, $2);
+            next
         }
-        when (/^ ([^+.]+) \+ ([^+]+) $/xms) {
+        elsif (/^ ([^+.]+) \+ ([^+]+) $/xms) {
             ($remotekey, $list_tag) = ($1, $2);
+            next
         }
-        when (/^ ([^+.]+) $/xms) {
+        elsif (/^ ([^+.]+) $/xms) {
             $remotekey = $1;
+            next
         }
 
         if (s/^ ([^+]+) \+ //xms) {
@@ -120,10 +125,8 @@ sub execute {
     my $rv;
 
     eval {
-        given ($job->{type}) {
-            when ('add_task') {
+        if ($job->{type} eq 'add_task') {
                 $rv = _add_task($job);
-            }
         }
     };
 

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 our $VERSION = '0.4';
-no warnings 'experimental::smartmatch';
+#no warnings 'experimental::smartmatch';
 
 use WebService::Simple;
 use Email::MIME;

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 our $VERSION = '0.4';
+no warnings 'experimental::smartmatch';
 
 use WebService::Simple;
 use Email::MIME;
@@ -171,14 +172,16 @@ sub _add_task {
         my $num = 1;
         for my $file (@{$job->{files}}) {
             my $ct = Mail::ToAPI::Text::_parse_header_fields("ct=$file->[1]");
-            push @{$post_params{Content}},
-                "add_files[$num]"   => [
-                    undef,
-                    encode_utf8($file->[0]),    # XXX
-                    Content_Type    => $file->[1],
-                    Content         => ($ct->{charset} ? encode($ct->{charset}, $file->[2]) : $file->[2]),
-                ];
-            ++$num;
+            if ($file->[0]) {
+	            push @{$post_params{Content}},
+	                "add_files[$num]"   => [
+	                    undef,
+	                    encode_utf8($file->[0]),    # XXX
+	                    Content_Type    => $file->[1],
+	                    Content         => ($ct->{charset} ? encode($ct->{charset}, $file->[2]) : $file->[2]),
+	                ];
+	            ++$num;
+			}
         }
     }
 

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -147,8 +147,10 @@ sub _add_task {
     );
 
     if ($job->{note}) {
+	    my $patched4markdown = $job->{note};
+	    $patched4markdown =~ s/(\r?\n)/  $1/g;
         push @{$post_params{Content}},
-            import_content_note => encode_utf8($job->{note});
+            import_content_note => encode_utf8($patched4markdown);
     }
 
     # in: [ [$filename, $content_type, $data] ... ]

--- a/lib/Mail/ToAPI/Checkvist.pm
+++ b/lib/Mail/ToAPI/Checkvist.pm
@@ -152,6 +152,7 @@ sub _add_task {
         Content => [
             import_content  => encode_utf8($job->{text}),
             parse_tasks     => 1,
+            from_email      => 1,
             remote_key      => $job->{remotekey},
         ],
     );

--- a/lib/Mail/ToAPI/Text.pm
+++ b/lib/Mail/ToAPI/Text.pm
@@ -84,7 +84,7 @@ sub _render_recur {
     my $filename = _conjure_filename($ct, $disp);
 
     if ($disp && $disp->{d} && $disp->{d} eq 'attachment') {
-        push @$files, [$disp->{filename}, $content_type,
+        push @$files, [$filename, $content_type,
             $content_type =~ /^text\// ? $part->body_str : $part->body];
     }
     else {

--- a/lib/Mail/ToAPI/Text.pm
+++ b/lib/Mail/ToAPI/Text.pm
@@ -3,7 +3,7 @@ package Mail::ToAPI::Text;
 use strict;
 use 5.010;
 our $VERSION = '0.1';
-no warnings 'experimental::smartmatch';
+#no warnings 'experimental::smartmatch';
 
 use parent qw/Exporter/;
 use HTML::Parser;

--- a/lib/Mail/ToAPI/Text.pm
+++ b/lib/Mail/ToAPI/Text.pm
@@ -55,11 +55,15 @@ sub _parse_ct_and_disp {
 sub _conjure_filename {
     my ($ct, $disp) = @_;
 
-    return $disp->{filename} // $ct->{name}
+    my $res = $disp->{filename} // $ct->{name}
         // do {
             (my $content_type = $ct->{ct}) =~ s{/}{-};
             "$content_type-file";
         };
+    if ($res =~ /rfc822-file$/) {
+        $res .= ".eml";
+    }
+    return $res;
 }
 
 sub _may_contain_text {
@@ -132,8 +136,10 @@ sub _parse_for_content {
     $body_str =~ s/^\s+//s;
 
     $body_str =~ s/(?:\r?\n|^)--[ ]?\r?\n.*\z//s;
+    
+    $body_str =~ s/ *=\r?\n?\z//s;
 
-    $body_str =~ s/\s+\z//s;
+    $body_str =~ s/[\r?\n\s]+\z//s;
 
     return ($body_str, $files);
 }

--- a/lib/Mail/ToAPI/Text.pm
+++ b/lib/Mail/ToAPI/Text.pm
@@ -3,6 +3,7 @@ package Mail::ToAPI::Text;
 use strict;
 use 5.010;
 our $VERSION = '0.1';
+no warnings 'experimental::smartmatch';
 
 use parent qw/Exporter/;
 use HTML::Parser;

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,1 @@
+find t -name *.t -exec perl -I lib {} \; -print

--- a/t/02-parse_email.t
+++ b/t/02-parse_email.t
@@ -39,6 +39,15 @@ is_email_parsed_ok('01-simple.eml', {
         note        => 'note1',
     });
 
+is_email_parsed_ok('011-simple-no-subject.eml', {
+    	text        => 'note1',
+    });
+
+is_email_parsed_ok('012-simple-no-subject-multiline.eml', {
+    	text        => 'note1',
+        note        => "note1\nnote1",
+    });
+
 is_email_parsed_ok('02-single-html.eml', {
         note        => "note2 in html\nw some Unicode: 🂄 and ♣\nline1\nline2",
     });

--- a/t/02-parse_email.t
+++ b/t/02-parse_email.t
@@ -40,13 +40,17 @@ is_email_parsed_ok('01-simple.eml', {
     });
 
 is_email_parsed_ok('011-simple-no-subject.eml', {
-    	text        => 'note1',
+    	text        => 'note133',
     });
 
 is_email_parsed_ok('012-simple-no-subject-multiline.eml', {
     	text        => 'note1',
         note        => "note1\nnote1",
     });
+is_email_parsed_ok('013-simple-blank-subject.eml', {
+    	text        => 'note1',
+    });
+
 
 is_email_parsed_ok('02-single-html.eml', {
         note        => "note2 in html\nw some Unicode: 🂄 and ♣\nline1\nline2",

--- a/t/03-parse_email_files.t
+++ b/t/03-parse_email_files.t
@@ -35,9 +35,15 @@ is_email_parsed_ok('05-mpmixed.eml', {
         ],
     });
 is_email_parsed_ok('051-mpmixed-ex.eml', {
-        note        => "A small attachment follows.\n\nSecond text file.",
+        note        => "A small attachment follows.\nSecond text file.",
         files       => [
-            ['x-something-something-file', 'x-something/something', "Third text file.\n\n"],
+            ['x-something-something-file', 'x-something/something', "Third text file.\n"],
+        ],
+    });
+is_email_parsed_ok('052-mpmixed-noname.eml', {
+        note        => "A small attachment follows.",
+        files       => [ 
+			[ undef, 'text/plain', "1\n"]
         ],
     });
 

--- a/t/03-parse_email_files.t
+++ b/t/03-parse_email_files.t
@@ -43,7 +43,14 @@ is_email_parsed_ok('051-mpmixed-ex.eml', {
 is_email_parsed_ok('052-mpmixed-noname.eml', {
         note        => "A small attachment follows.",
         files       => [ 
-			[ undef, 'text/plain', "1\n"]
+			[ 'text-plain-file', 'text/plain', "1\n"]
+        ],
+    });
+
+is_email_parsed_ok('053-noname-rfc822-message.eml', {
+        note        => "A small attachment follows.",
+        files       => [ 
+			[ 'message-rfc822-file.eml', 'message/rfc822', "1\n"]
         ],
     });
 

--- a/t/eml/011-simple-no-subject.eml
+++ b/t/eml/011-simple-no-subject.eml
@@ -1,0 +1,5 @@
+From: Vasya <vasya@example.com>
+To: Checkvist <key1@example.com>
+
+note1  
+

--- a/t/eml/012-simple-no-subject-multiline.eml
+++ b/t/eml/012-simple-no-subject-multiline.eml
@@ -1,0 +1,6 @@
+From: Vasya <vasya@example.com>
+To: Checkvist <key1@example.com>
+
+note1
+note1  
+

--- a/t/eml/013-simple-blank-subject.eml
+++ b/t/eml/013-simple-blank-subject.eml
@@ -1,4 +1,7 @@
 From: Vasya <vasya@example.com>
 To: Checkvist <key1@example.com>
+Subject:
 
-note133
+note1
+note1  
+

--- a/t/eml/052-mpmixed-noname.eml
+++ b/t/eml/052-mpmixed-noname.eml
@@ -1,0 +1,34 @@
+X-Mailer: YahooMailWebService/0.8.150.561
+Date: Sat, 27 Jul 2013 06:52:52 -0700 (PDT)
+From: Alex Kapranoff <quappa@example.com>
+Subject: mp/mixed
+To: "kappa@example.com" <kappa@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="1261493821-427627832-1374933172=:48936"
+
+--1261493821-427627832-1374933172=:48936
+Content-Type: multipart/alternative; boundary="1261493821-86222521-1374933172=:48936"
+
+--1261493821-86222521-1374933172=:48936
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+A small attachment follows.=0A=0A=0A=A0-- =0A=0AAlex Kapranoff.=0A
+--1261493821-86222521-1374933172=:48936
+Content-Type: text/html; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+<html><body><div style=3D"color:#000; background-color:#fff; font-family:ti=
+mes new roman, new york, times, serif;font-size:12pt">A small attachment fo=
+llows.<br><div><span><br></span></div><div>-- <br></div><div>Alex Kap=
+ranoff.<br></div></div></body></html>
+--1261493821-86222521-1374933172=:48936--
+--1261493821-427627832-1374933172=:48936
+Content-Type: text/plain; 
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; 
+
+MQo=
+
+--1261493821-427627832-1374933172=:48936--
+

--- a/t/eml/053-noname-rfc822-message.eml
+++ b/t/eml/053-noname-rfc822-message.eml
@@ -1,0 +1,34 @@
+X-Mailer: YahooMailWebService/0.8.150.561
+Date: Sat, 27 Jul 2013 06:52:52 -0700 (PDT)
+From: Alex Kapranoff <quappa@example.com>
+Subject: mp/mixed
+To: "kappa@example.com" <kappa@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="1261493821-427627832-1374933172=:48936"
+
+--1261493821-427627832-1374933172=:48936
+Content-Type: multipart/alternative; boundary="1261493821-86222521-1374933172=:48936"
+
+--1261493821-86222521-1374933172=:48936
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+A small attachment follows.=0A=0A=0A=A0-- =0A=0AAlex Kapranoff.=0A
+--1261493821-86222521-1374933172=:48936
+Content-Type: text/html; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+<html><body><div style=3D"color:#000; background-color:#fff; font-family:ti=
+mes new roman, new york, times, serif;font-size:12pt">A small attachment fo=
+llows.<br><div><span><br></span></div><div>-- <br></div><div>Alex Kap=
+ranoff.<br></div></div></body></html>
+--1261493821-86222521-1374933172=:48936--
+--1261493821-427627832-1374933172=:48936
+Content-Transfer-Encoding: base64
+Content-Type: message/rfc822
+Content-Disposition: attachment; creation-date="Thu, 31 Aug 2017 07:46:39 GMT"; modification-date="Thu, 31 Aug 2017 07:46:39 GMT"
+
+MQo=
+
+--1261493821-427627832-1374933172=:48936--
+


### PR DESCRIPTION
When Markdown support is enabled, linebreaks in the the imported notes are ignored.
To enforce linebreaks, I add two spaces at the end of each line.
